### PR TITLE
Implement node caching

### DIFF
--- a/Editor/CommonsCookBook.cs
+++ b/Editor/CommonsCookBook.cs
@@ -1373,6 +1373,10 @@ public class CommonsCookBook : CookBook
     {
         try
         {
+            if (nodeUI == null) {
+                return; // probably a redirect node
+            }
+
             if (nodeUI?.Node?.Name?.StartsWith("vars.") ?? false)
             {
                 nodeUI.DataInputs?.First()?.SetEnabled(false);

--- a/Editor/NodeDefCache.cs
+++ b/Editor/NodeDefCache.cs
@@ -1,0 +1,87 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace NoodledEvents
+{
+    /// <summary>
+    /// Serializable cache for NodeDef data. Stores everything except UI elements.
+    /// </summary>
+    [Serializable]
+    public class NodeDefCache
+    {
+        [Serializable]
+        public class CachedNodeDef
+        {
+            public string Name;
+            public string CookBookName; // Name of the cookbook asset
+            public CachedPin[] Inputs;
+            public CachedPin[] Outputs;
+            public string BookTag;
+            public string SearchTextOverride;
+            public string TooltipOverride;
+        }
+
+        [Serializable]
+        public class CachedPin
+        {
+            public string Name;
+            public string TypeFullName; // Store as string for serialization
+            public bool Const;
+            
+            public Type GetPinType()
+            {
+                if (string.IsNullOrEmpty(TypeFullName)) return null;
+                return TypeCache.GetType(TypeFullName);
+            }
+        }
+
+        public static CachedNodeDef ToCached(CookBook.NodeDef nodeDef)
+        {
+            return new CachedNodeDef
+            {
+                Name = nodeDef.Name,
+                CookBookName = nodeDef.CookBook?.name,
+                BookTag = nodeDef.BookTag,
+                SearchTextOverride = string.Empty, // Will be reconstructed from name
+                TooltipOverride = string.Empty,
+                Inputs = nodeDef.Inputs?.Select(p => new CachedPin
+                {
+                    Name = p.Name,
+                    TypeFullName = p.Type?.AssemblyQualifiedName,
+                    Const = p.Const
+                }).ToArray() ?? Array.Empty<CachedPin>(),
+                Outputs = nodeDef.Outputs?.Select(p => new CachedPin
+                {
+                    Name = p.Name,
+                    TypeFullName = p.Type?.AssemblyQualifiedName,
+                    Const = p.Const
+                }).ToArray() ?? Array.Empty<CachedPin>()
+            };
+        }
+
+        public static CookBook.NodeDef FromCached(CachedNodeDef cached, CookBook cookbook)
+        {
+            return new CookBook.NodeDef(
+                book: cookbook,
+                name: cached.Name,
+                inputs: () => cached.Inputs?.Select(p => new CookBook.NodeDef.Pin(
+                    p.Name,
+                    p.GetPinType(),
+                    p.Const
+                )).ToArray() ?? Array.Empty<CookBook.NodeDef.Pin>(),
+                outputs: () => cached.Outputs?.Select(p => new CookBook.NodeDef.Pin(
+                    p.Name,
+                    p.GetPinType(),
+                    p.Const
+                )).ToArray() ?? Array.Empty<CookBook.NodeDef.Pin>(),
+                bookTag: cached.BookTag ?? "",
+                searchTextOverride: cached.SearchTextOverride ?? "",
+                tooltipOverride: cached.TooltipOverride ?? ""
+            );
+        }
+    }
+}
+#endif

--- a/Editor/NodeDefCache.cs.meta
+++ b/Editor/NodeDefCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8885c066bd3f6e347bbc855da2738c2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/NodeDefCacheManager.cs
+++ b/Editor/NodeDefCacheManager.cs
@@ -1,0 +1,310 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using UnityEditor;
+using UnityEngine;
+
+namespace NoodledEvents
+{
+    /// <summary>
+    /// Manages persistent caching of NodeDefs to improve loading speed.
+    /// </summary>
+    public static class NodeDefCacheManager
+    {
+        private const string CACHE_FILE_PATH = "Library/NoodleNodeDefCache.bin";
+        private const string CACHE_VERSION = "2.0";
+
+        public static bool TryLoadCache(CookBook[] allBooks, out List<CookBook.NodeDef> nodeDefs, bool rebuildOnAssemblyChange = false, 
+            Action<int, int, float> progressCallback = null)
+        {
+            nodeDefs = new List<CookBook.NodeDef>();
+
+            if (!File.Exists(CACHE_FILE_PATH))
+            {
+                Debug.Log("[NodeCache] No cache file found, will generate fresh.");
+                return false;
+            }
+
+            try
+            {
+                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+                TypeCache.Initialize();
+
+                using (FileStream fileStream = new FileStream(CACHE_FILE_PATH, FileMode.Open, FileAccess.Read, FileShare.Read, 
+                    bufferSize: 2 * 1024 * 1024)) // 2MB buffer for faster reads
+                using (GZipStream gzipStream = new GZipStream(fileStream, CompressionMode.Decompress))
+                using (BinaryReader reader = new BinaryReader(gzipStream))
+                {
+                    // Read header
+                    string version = reader.ReadString();
+                    string unityVersion = reader.ReadString();
+                    long assemblyTimestamp = reader.ReadInt64();
+
+                    // Validate cache
+                    if (version != CACHE_VERSION)
+                    {
+                        Debug.Log($"[NodeCache] Cache version mismatch: {version} != {CACHE_VERSION}");
+                        return false;
+                    }
+
+                    if (unityVersion != Application.unityVersion)
+                    {
+                        Debug.Log($"[NodeCache] Unity version changed: {unityVersion} -> {Application.unityVersion}");
+                        return false;
+                    }
+
+                    long currentTimestamp = GetAssemblyTimestamp();
+                    if (assemblyTimestamp != currentTimestamp)
+                    {
+                        if (rebuildOnAssemblyChange)
+                        {     
+                            Debug.Log($"[NodeCache] Assembly changed: {assemblyTimestamp} -> {currentTimestamp}");
+                            return false;
+                        }
+                        else
+                            Debug.LogWarning("[NodeCache] Assembly change detected but rebuildOnAssemblyChange is false. Attempting to load cache anyway...");
+                    }
+
+                    // Build cookbook lookup
+                    var cookbookLookup = allBooks.ToDictionary(b => b.name, b => b);
+
+                    // Read node count
+                    int nodeCount = reader.ReadInt32();
+                    nodeDefs = new List<CookBook.NodeDef>(nodeCount);
+
+                    // Progress reporting setup
+                    const int REPORT_INTERVAL = 10000; // Report every 10k nodes
+                    int lastReportedCount = 0;
+                    var progressStopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+                    // Stream nodes in batches for better performance
+                    for (int i = 0; i < nodeCount; i++)
+                    {
+                        var cached = ReadCachedNodeDef(reader);
+                        
+                        if (cookbookLookup.TryGetValue(cached.CookBookName, out var cookbook))
+                        {
+                            var nodeDef = NodeDefCache.FromCached(cached, cookbook);
+                            nodeDefs.Add(nodeDef);
+                        }
+
+                        // Report progress periodically
+                        if (progressCallback != null && (i - lastReportedCount >= REPORT_INTERVAL || i == nodeCount - 1))
+                        {
+                            float percentage = (i + 1) / (float)nodeCount;
+                            progressCallback?.Invoke(i + 1, nodeCount, percentage);
+                            lastReportedCount = i;
+                        }
+                    }
+                }
+
+                stopwatch.Stop();
+                float totalSeconds = stopwatch.ElapsedMilliseconds / 1000f;
+                float nodesPerSec = nodeDefs.Count / totalSeconds;
+                Debug.Log($"[NodeCache] Successfully loaded {nodeDefs.Count:N0} nodes from cache in {stopwatch.ElapsedMilliseconds}ms ({nodesPerSec:N0} nodes/sec)!");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[NodeCache] Failed to load cache: {ex.Message}");
+                return false;
+            }
+        }
+
+        public static void SaveCache(List<CookBook.NodeDef> nodeDefs, Action<int, int, float> progressCallback = null)
+        {
+            try
+            {
+                var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+                // Phase 1: Convert to cached format
+                Debug.Log($"[NodeCache] Converting {nodeDefs.Count:N0} nodes to cache format...");
+                var conversionStopwatch = System.Diagnostics.Stopwatch.StartNew();
+                
+                var cachedDefs = new NodeDefCache.CachedNodeDef[nodeDefs.Count];
+                int processed = 0;
+                
+                for (int i = 0; i < nodeDefs.Count; i++)
+                {
+                    cachedDefs[i] = NodeDefCache.ToCached(nodeDefs[i]);
+                    int current = processed++;
+                    if (current % 10000 == 0 || current == nodeDefs.Count)
+                    {
+                        float percentage = current / (float)nodeDefs.Count;
+                        progressCallback?.Invoke(current, nodeDefs.Count, percentage);
+                    }
+                }
+
+                conversionStopwatch.Stop();
+                Debug.Log($"[NodeCache] Conversion completed in {conversionStopwatch.ElapsedMilliseconds}ms ({nodeDefs.Count / (conversionStopwatch.ElapsedMilliseconds / 1000f):N0} nodes/sec)");
+
+                // Phase 2: Write to disk with compression
+                Debug.Log($"[NodeCache] Writing cache to disk...");
+                var writeStopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+                using (FileStream fileStream = new FileStream(CACHE_FILE_PATH, FileMode.Create, FileAccess.Write, FileShare.None,
+                    bufferSize: 1024 * 1024)) // 1MB buffer for faster writes
+                using (GZipStream gzipStream = new GZipStream(fileStream, System.IO.Compression.CompressionLevel.Optimal))
+                using (BinaryWriter writer = new BinaryWriter(gzipStream))
+                {
+                    // Write header
+                    writer.Write(CACHE_VERSION);
+                    writer.Write(Application.unityVersion);
+                    writer.Write(GetAssemblyTimestamp());
+
+                    // Write node count
+                    writer.Write(cachedDefs.Length);
+
+                    // Write each node with progress
+                    int lastReported = 0;
+                    for (int i = 0; i < cachedDefs.Length; i++)
+                    {
+                        WriteCachedNodeDef(writer, cachedDefs[i]);
+
+                        if (progressCallback != null && (i - lastReported >= 10000 || i == cachedDefs.Length - 1))
+                        {
+                            float percentage = (i + 1) / (float)cachedDefs.Length;
+                            progressCallback?.Invoke(i + 1, cachedDefs.Length, percentage);
+                            lastReported = i;
+                        }
+                    }
+                }
+
+                writeStopwatch.Stop();
+                stopwatch.Stop();
+
+                var fileInfo = new FileInfo(CACHE_FILE_PATH);
+                float totalSeconds = stopwatch.ElapsedMilliseconds / 1000f;
+                float nodesPerSec = nodeDefs.Count / totalSeconds;
+                float mbSize = fileInfo.Length / 1024f / 1024f;
+                
+                Debug.Log($"[NodeCache] Cache saved successfully:");
+                Debug.Log($"  - Total time: {stopwatch.ElapsedMilliseconds}ms ({nodesPerSec:N0} nodes/sec)");
+                Debug.Log($"  - Conversion: {conversionStopwatch.ElapsedMilliseconds}ms");
+                Debug.Log($"  - Write+Compress: {writeStopwatch.ElapsedMilliseconds}ms");
+                Debug.Log($"  - File size: {mbSize:F2}MB ({nodeDefs.Count / mbSize:N0} nodes/MB)");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[NodeCache] Failed to save cache: {ex.Message} {ex.StackTrace}");
+            }
+        }
+
+        public static void ClearCache()
+        {
+            if (File.Exists(CACHE_FILE_PATH))
+            {
+                File.Delete(CACHE_FILE_PATH);
+                Debug.Log("[NodeCache] Cache cleared.");
+            }
+        }
+
+        private static long GetAssemblyTimestamp()
+        {
+            try
+            {
+                string[] assemblyPaths = new[]
+                {
+                    "Library/ScriptAssemblies/Assembly-CSharp.dll",
+                    "Library/ScriptAssemblies/Assembly-CSharp-Editor.dll"
+                };
+
+                long maxTimestamp = 0;
+                foreach (var path in assemblyPaths)
+                {
+                    if (File.Exists(path))
+                    {
+                        long timestamp = File.GetLastWriteTime(path).Ticks;
+                        if (timestamp > maxTimestamp)
+                            maxTimestamp = timestamp;
+                    }
+                }
+
+                return maxTimestamp;
+            }
+            catch
+            {
+                return DateTime.Now.Ticks;
+            }
+        }
+
+        private static void WriteCachedNodeDef(BinaryWriter writer, NodeDefCache.CachedNodeDef cached)
+        {
+            writer.Write(cached.Name ?? string.Empty);
+            writer.Write(cached.CookBookName ?? string.Empty);
+            writer.Write(cached.BookTag ?? string.Empty);
+            writer.Write(cached.SearchTextOverride ?? string.Empty);
+            writer.Write(cached.TooltipOverride ?? string.Empty);
+
+            // Write inputs
+            writer.Write(cached.Inputs?.Length ?? 0);
+            if (cached.Inputs != null)
+            {
+                foreach (var pin in cached.Inputs)
+                {
+                    writer.Write(pin.Name ?? string.Empty);
+                    writer.Write(pin.TypeFullName ?? string.Empty);
+                    writer.Write(pin.Const);
+                }
+            }
+
+            // Write outputs
+            writer.Write(cached.Outputs?.Length ?? 0);
+            if (cached.Outputs != null)
+            {
+                foreach (var pin in cached.Outputs)
+                {
+                    writer.Write(pin.Name ?? string.Empty);
+                    writer.Write(pin.TypeFullName ?? string.Empty);
+                    writer.Write(pin.Const);
+                }
+            }
+        }
+
+        private static NodeDefCache.CachedNodeDef ReadCachedNodeDef(BinaryReader reader)
+        {
+            var cached = new NodeDefCache.CachedNodeDef
+            {
+                Name = reader.ReadString(),
+                CookBookName = reader.ReadString(),
+                BookTag = reader.ReadString(),
+                SearchTextOverride = reader.ReadString(),
+                TooltipOverride = reader.ReadString()
+            };
+
+            // Read inputs
+            int inputCount = reader.ReadInt32();
+            cached.Inputs = new NodeDefCache.CachedPin[inputCount];
+            for (int i = 0; i < inputCount; i++)
+            {
+                cached.Inputs[i] = new NodeDefCache.CachedPin
+                {
+                    Name = reader.ReadString(),
+                    TypeFullName = reader.ReadString(),
+                    Const = reader.ReadBoolean()
+                };
+            }
+
+            // Read outputs
+            int outputCount = reader.ReadInt32();
+            cached.Outputs = new NodeDefCache.CachedPin[outputCount];
+            for (int i = 0; i < outputCount; i++)
+            {
+                cached.Outputs[i] = new NodeDefCache.CachedPin
+                {
+                    Name = reader.ReadString(),
+                    TypeFullName = reader.ReadString(),
+                    Const = reader.ReadBoolean()
+                };
+            }
+
+            return cached;
+        }
+    }
+}
+#endif

--- a/Editor/NodeDefCacheManager.cs.meta
+++ b/Editor/NodeDefCacheManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b036a37cc97f144390b197742930800
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ObjectFieldCookBook.cs
+++ b/Editor/ObjectFieldCookBook.cs
@@ -14,7 +14,7 @@ using static NoodledEvents.CookBook.NodeDef;
 
 public class ObjectFieldCookBook : CookBook
 {
-    internal Dictionary<FieldInfo, (NodeDef, NodeDef)> MyDefs = new();
+    internal List<(NodeDef, NodeDef)> MyDefs = new();
     public override void CollectDefs(Action<IEnumerable<NodeDef>, float> progressCallback, Action completedCallback)
     {
         MyDefs.Clear();
@@ -57,7 +57,7 @@ public class ObjectFieldCookBook : CookBook
                         tooltipOverride: $"{t.Namespace}.{t.GetFriendlyName()}.setf_{field.Name} (Reflection), {t.Assembly.FullName.Split(',')[0]}")
                     );
                     newDefs.Add(setter);
-                    UltNoodleEditor.MainThread.Enqueue(() => MyDefs.Add(field, (getter, setter)));
+                    UltNoodleEditor.MainThread.Enqueue(() => MyDefs.Add((getter, setter)));
                 }
                 progressCallback.Invoke(newDefs, (++i / (float)UltNoodleEditor.SearchableTypes.Length));
             }
@@ -320,12 +320,10 @@ public class ObjectFieldCookBook : CookBook
             {
                 if (field.DeclaringType != t) continue;
 
-                // reflection :)
-                //if (!(typeof(UnityEngine.Object).IsAssignableFrom(field.FieldType) || field.FieldType == typeof(string) || field.FieldType == typeof(int) || field.FieldType == typeof(float) || field.FieldType == typeof(bool))) continue;
-                //if (field.GetCustomAttribute<NonSerializedAttribute>() != null) continue;
-                //if (!(field.IsPublic || field.GetCustomAttribute<SerializeField>() != null)) continue;
+                var bookTag = SerializedField.GetBookTag(field);
 
-                if (!MyDefs.TryGetValue(field, out (NodeDef, NodeDef) nodes)) continue;
+                var nodes = MyDefs.Find(nd => nd.Item1.BookTag == bookTag);
+                if (nodes == default((NodeDef, NodeDef))) continue;
 
                 if (!field.IsStatic)
                 {

--- a/Editor/ObjectFieldCookBook.cs
+++ b/Editor/ObjectFieldCookBook.cs
@@ -14,7 +14,7 @@ using static NoodledEvents.CookBook.NodeDef;
 
 public class ObjectFieldCookBook : CookBook
 {
-    private Dictionary<FieldInfo, (NodeDef, NodeDef)> MyDefs = new();
+    internal Dictionary<FieldInfo, (NodeDef, NodeDef)> MyDefs = new();
     public override void CollectDefs(Action<IEnumerable<NodeDef>, float> progressCallback, Action completedCallback)
     {
         MyDefs.Clear();

--- a/Editor/ObjectMethodCookBook.cs
+++ b/Editor/ObjectMethodCookBook.cs
@@ -16,7 +16,7 @@ using static NoodledEvents.CookBook.NodeDef;
 
 public class ObjectMethodCookBook : CookBook
 {
-    internal Dictionary<MethodInfo, NodeDef> MyDefs = new();
+    internal List<NodeDef> MyDefs = new();
     public override void CollectDefs(Action<IEnumerable<NodeDef>, float> progressCallback, Action completedCallback)
     {
         MyDefs.Clear();
@@ -99,7 +99,7 @@ public class ObjectMethodCookBook : CookBook
                         tooltipOverride: descriptiveText);
                     newNodes.Add(newDef);
 
-                    UltNoodleEditor.MainThread.Enqueue(() => MyDefs.Add(meth, newDef));
+                    UltNoodleEditor.MainThread.Enqueue(() => MyDefs.Add(newDef));
 
                 }
                 progressCallback.Invoke(newNodes, (++i / (float)UltNoodleEditor.SearchableTypes.Length));
@@ -875,7 +875,10 @@ public class ObjectMethodCookBook : CookBook
             foreach (var method in firsts.Concat(lasts))
             {
                 if (props.Any(p => p.GetMethod == method || p.SetMethod == method)) continue;
-                if (!MyDefs.TryGetValue(method, out NodeDef def)) continue;
+
+                var bookTag = SerializedMethod.GetBookTag(method);
+                var def = MyDefs.Find(d => d.BookTag == bookTag);
+                if (def == default(NodeDef)) continue;
 
                 // lets collapse each overload into a submenu!
                 // also collapse "Injected" methods
@@ -891,13 +894,20 @@ public class ObjectMethodCookBook : CookBook
             }
             foreach (var prop in props)
             {
-                if (prop.CanRead && MyDefs.TryGetValue(prop.GetMethod, out NodeDef getter))
+                if (prop.CanRead)
                 {
-                    o.TryAdd(tName + "/Properties/" + getter.SearchItem.text.Replace(".get_", ".").Split('(').First() + "/Get", getter);
+                    string getterBookTag = SerializedMethod.GetBookTag(prop.GetMethod);
+                    var getter = MyDefs.Find(p => p.BookTag == getterBookTag);
+                    if (getter != default)
+                        o.TryAdd(tName + "/Properties/" + getter.SearchItem.text.Replace(".get_", ".").Split('(').First() + "/Get", getter);
                 }
-                if (prop.CanWrite && MyDefs.TryGetValue(prop.SetMethod, out NodeDef setter))
+                
+                if (prop.CanWrite)
                 {
-                    o.TryAdd(tName + "/Properties/" + setter.SearchItem.text.Replace(".set_", ".").Split('(').First() + "/Set", setter);
+                    string setterBookTag = SerializedMethod.GetBookTag(prop.SetMethod);
+                    var setter = MyDefs.Find(p => p.BookTag == setterBookTag);
+                    if (setter != default)
+                        o.TryAdd(tName + "/Properties/" + setter.SearchItem.text.Replace(".set_", ".").Split('(').First() + "/Set", setter);
                 }
             }
         }

--- a/Editor/ObjectMethodCookBook.cs
+++ b/Editor/ObjectMethodCookBook.cs
@@ -16,7 +16,7 @@ using static NoodledEvents.CookBook.NodeDef;
 
 public class ObjectMethodCookBook : CookBook
 {
-    private Dictionary<MethodInfo, NodeDef> MyDefs = new();
+    internal Dictionary<MethodInfo, NodeDef> MyDefs = new();
     public override void CollectDefs(Action<IEnumerable<NodeDef>, float> progressCallback, Action completedCallback)
     {
         MyDefs.Clear();

--- a/Editor/StaticMethodCookBook.cs
+++ b/Editor/StaticMethodCookBook.cs
@@ -15,7 +15,7 @@ using static NoodledEvents.CookBook.NodeDef;
 
 public class StaticMethodCookBook : CookBook
 {
-    internal Dictionary<MethodInfo, NodeDef> MyDefs = new();
+    internal List<NodeDef> MyDefs = new();
     public override void CollectDefs(Action<IEnumerable<NodeDef>, float> progressCallback, Action completedCallback)
     {
         MyDefs.Clear();
@@ -104,7 +104,7 @@ public class StaticMethodCookBook : CookBook
                         searchTextOverride: searchText,
                         tooltipOverride: descriptiveText);
                     newDefs.Add(newDef);
-                    UltNoodleEditor.MainThread.Enqueue(() => MyDefs.Add(meth, newDef));
+                    UltNoodleEditor.MainThread.Enqueue(() => MyDefs.Add(newDef));
                 }
                 progressCallback.Invoke(newDefs, (++i / (float)UltNoodleEditor.SearchableTypes.Length));
             }
@@ -269,7 +269,9 @@ public class StaticMethodCookBook : CookBook
             
             foreach (var method in meths.Distinct())
             {
-                if (!MyDefs.TryGetValue(method, out NodeDef def)) continue;
+                var bookTag = SerializedMethod.GetBookTag(method);
+                var def = MyDefs.Find(d => d.BookTag == bookTag);
+                if (def == default) continue;
 
                 // lets collapse each overload into a submenu!
                 // also collapse "Injected" methods
@@ -283,13 +285,20 @@ public class StaticMethodCookBook : CookBook
             }
             foreach (var prop in props)
             {
-                if (prop.CanRead && MyDefs.TryGetValue(prop.GetMethod, out NodeDef getter))
+                if (prop.CanRead)
                 {
-                    o.TryAdd(tName + "/Static/Properties/" + getter.SearchItem.text.Replace(".get_", ".").Split('(').First() + "/Get", getter);
+                    string getterBookTag = SerializedMethod.GetBookTag(prop.GetMethod);
+                    var getter = MyDefs.Find(p => p.BookTag == getterBookTag);
+                    if (getter != default)
+                        o.TryAdd(tName + "/Static/Properties/" + getter.SearchItem.text.Replace(".get_", ".").Split('(').First() + "/Get", getter);
                 }
-                if (prop.CanWrite && MyDefs.TryGetValue(prop.SetMethod, out NodeDef setter))
+                
+                if (prop.CanWrite)
                 {
-                    o.TryAdd(tName + "/Static/Properties/" + setter.SearchItem.text.Replace(".set_", ".").Split('(').First() + "/Set", setter);
+                    string setterBookTag = SerializedMethod.GetBookTag(prop.SetMethod);
+                    var setter = MyDefs.Find(p => p.BookTag == setterBookTag);
+                    if (setter != default)
+                        o.TryAdd(tName + "/Static/Properties/" + setter.SearchItem.text.Replace(".set_", ".").Split('(').First() + "/Set", setter);
                 }
             }
         }

--- a/Editor/StaticMethodCookBook.cs
+++ b/Editor/StaticMethodCookBook.cs
@@ -15,7 +15,7 @@ using static NoodledEvents.CookBook.NodeDef;
 
 public class StaticMethodCookBook : CookBook
 {
-    private Dictionary<MethodInfo, NodeDef> MyDefs = new();
+    internal Dictionary<MethodInfo, NodeDef> MyDefs = new();
     public override void CollectDefs(Action<IEnumerable<NodeDef>, float> progressCallback, Action completedCallback)
     {
         MyDefs.Clear();

--- a/Editor/TypeCache.cs
+++ b/Editor/TypeCache.cs
@@ -1,0 +1,138 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace NoodledEvents
+{
+    public static class TypeCache
+    {
+        private static Dictionary<string, Type> _cache = new Dictionary<string, Type>();
+        private static bool _initialized = false;
+        private static readonly object _lock = new object();
+
+        public static void Initialize()
+        {
+            lock (_lock)
+            {
+                if (_initialized) return;
+
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+
+                // Get all relevant assemblies
+                var assemblies = new List<System.Reflection.Assembly>();
+
+                // Unity assemblies
+                assemblies.Add(typeof(UnityEngine.GameObject).Assembly); // UnityEngine
+                assemblies.Add(typeof(UnityEditor.Editor).Assembly);      // UnityEditor
+
+                // Game assemblies
+                var gameAssemblies = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(a => a.FullName.StartsWith("Assembly-CSharp"));
+                assemblies.AddRange(gameAssemblies);
+
+                // XR Toolkit if available
+                var xrAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                    .FirstOrDefault(a => a.FullName.StartsWith("Unity.XR.Interaction.Toolkit"));
+                if (xrAssembly != null)
+                    assemblies.Add(xrAssembly);
+
+                // Other Unity assemblies that might be used
+                var otherAssemblies = AppDomain.CurrentDomain.GetAssemblies()
+                    .Where(a => a.FullName.StartsWith("UnityEngine.") || 
+                                a.FullName.StartsWith("Unity.") ||
+                                a.FullName.StartsWith("System"));
+                assemblies.AddRange(otherAssemblies);
+
+                // Pre-cache all types
+                int typeCount = 0;
+                foreach (var assembly in assemblies.Distinct())
+                {
+                    try
+                    {
+                        foreach (var type in assembly.GetTypes())
+                        {
+                            try
+                            {
+                                // Cache by AssemblyQualifiedName (full name)
+                                if (!string.IsNullOrEmpty(type.AssemblyQualifiedName))
+                                {
+                                    _cache[type.AssemblyQualifiedName] = type;
+                                    typeCount++;
+                                }
+
+                                // Also cache by FullName (for partial matches)
+                                if (!string.IsNullOrEmpty(type.FullName))
+                                {
+                                    _cache[type.FullName] = type;
+                                }
+
+                                // Cache simple name for common types
+                                if (!string.IsNullOrEmpty(type.Name))
+                                {
+                                    _cache[type.Name] = type;
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                // Some types can't be reflected (generic, nested, etc)
+                                // Just skip them
+                            }
+                        }
+                    }
+                    catch (System.Reflection.ReflectionTypeLoadException)
+                    {
+                        // Assembly has types that can't be loaded, skip it
+                    }
+                }
+
+                _initialized = true;
+                sw.Stop();
+                
+                Debug.Log($"[TypeCache] Initialized with {typeCount:N0} types from {assemblies.Count} assemblies in {sw.ElapsedMilliseconds}ms");
+            }
+        }
+
+        public static Type GetType(string typeName)
+        {
+            if (string.IsNullOrEmpty(typeName)) 
+                return null;
+
+            // Ensure cache is initialized
+            if (!_initialized)
+                Initialize();
+
+            // Try cache first (fast path)
+            if (_cache.TryGetValue(typeName, out var type))
+                return type;
+
+            // Fallback to slow Type.GetType() and cache result
+            type = Type.GetType(typeName);
+            if (type != null)
+            {
+                lock (_lock)
+                {
+                    _cache[typeName] = type;
+                }
+            }
+
+            return type;
+        }
+
+        public static void Clear()
+        {
+            lock (_lock)
+            {
+                _cache.Clear();
+                _initialized = false;
+            }
+        }
+
+        public static (int cachedTypes, bool initialized) GetStats()
+        {
+            return (_cache.Count, _initialized);
+        }
+    }
+}
+#endif

--- a/Editor/TypeCache.cs.meta
+++ b/Editor/TypeCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2bee127ceb450b43b291bd05ef20bfe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/UltNoodleEditor.cs
+++ b/Editor/UltNoodleEditor.cs
@@ -57,7 +57,7 @@ public class UltNoodleEditor : EditorWindow
     }
 
     public UltNoodleTreeView TreeView => treeView;
-    
+
     private UltNoodleTreeView treeView;
     private UltNoodleInspectorView inspectorView;
     private UltNoodleBowlSelector bowlSelector;
@@ -88,7 +88,7 @@ public class UltNoodleEditor : EditorWindow
         Selection.selectionChanged += () => contextChanged(EditorPrefs.GetBool("SelectedBowlsOnly", true));
 
         // Fixes issue where having the editor open when going in then out of play mode causes the search window to infinitely throw exceptions
-        EditorApplication.playModeStateChanged += (_) => contextChanged();
+        //EditorApplication.playModeStateChanged += (_) => contextChanged();
         EditorApplication.playModeStateChanged += (_) => Editor.Close();
 
         treeView = root.Q<UltNoodleTreeView>();
@@ -110,7 +110,12 @@ public class UltNoodleEditor : EditorWindow
         var compilationMenu = root.Q<ToolbarMenu>("CompilationMenu");
         var helpMenu = root.Q<ToolbarMenu>("HelpMenu");
 
-        nodesMenu.menu.AppendAction("Regenerate Nodes", (a) => CollectNodes(), (a) => _collecting ? DropdownMenuAction.Status.Disabled : DropdownMenuAction.Status.Normal);
+        nodesMenu.menu.AppendAction("Force Regenerate Nodes", (a) => CollectNodes(true), (a) => _collecting ? DropdownMenuAction.Status.Disabled : DropdownMenuAction.Status.Normal);
+        nodesMenu.menu.AppendAction("Rebuild Nodes on Assembly Change", (a) =>
+        {
+            bool enabled = !EditorPrefs.GetBool("RebuildOnAssemblyChange", false); // default to false, most nodes won't change on assembly since custom scripts don't work
+            EditorPrefs.SetBool("RebuildOnAssemblyChange", enabled);
+        }, (a) => EditorPrefs.GetBool("RebuildOnAssemblyChange", false) ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal);
 
         void UpdateSplit() => UpdateLeftSplitVisibility(leftSplit, mainSplit, inspectorView.visible, bowlSelector.visible);
         viewMenu.menu.AppendAction("Inspector", (a) => { inspectorView.visible = !inspectorView.visible; UpdateSplit(); }, (a) => inspectorView.visible ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal);
@@ -123,17 +128,17 @@ public class UltNoodleEditor : EditorWindow
             _bowlToReselect = !enabled || Selection.activeGameObject == _currentBowl?.SerializedData?.gameObject
                 ? _currentBowl?.SerializedData
                 : null; // only reselect if we're disabling the toggle or the current bowl's gameobject is selected
-            
+
             ResetViews();
             OnFocus(); // update displays
         }, (a) => EditorPrefs.GetBool("SelectedBowlsOnly", true) ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal);
         viewMenu.menu.AppendAction("Rebuild View", (a) => contextChanged(), (a) => DropdownMenuAction.Status.Normal);
 
-        compilationMenu.menu.AppendAction("Add Debug Logs", (_) => 
-            UltNoodleRuntimeExtensions.DEBUG_IN_COMP = !UltNoodleRuntimeExtensions.DEBUG_IN_COMP, 
+        compilationMenu.menu.AppendAction("Add Debug Logs", (_) =>
+            UltNoodleRuntimeExtensions.DEBUG_IN_COMP = !UltNoodleRuntimeExtensions.DEBUG_IN_COMP,
             (_) => UltNoodleRuntimeExtensions.DEBUG_IN_COMP ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal);
 
-        compilationMenu.menu.AppendAction("Use Inline Ultswaps", (_) => 
+        compilationMenu.menu.AppendAction("Use Inline Ultswaps", (_) =>
         {
             bool enabled = !EditorPrefs.GetBool("InlineUltswaps");
             EditorPrefs.SetBool("InlineUltswaps", enabled);
@@ -200,7 +205,7 @@ public class UltNoodleEditor : EditorWindow
 
     private Label LoadingText;
     private static bool _collecting;
-    
+
     private static Type[] s_tps;
     public static Type[] SearchableTypes
     {
@@ -216,16 +221,29 @@ public class UltNoodleEditor : EditorWindow
         }
     }
 
-    private void CollectNodes()
+    private void CollectNodes(bool skipCache = false)
     {
         if (_collecting) return;
         _collecting = true;
 
         // Creates all NodeDefs, clearing the pre-existing ones
         AllNodeDefs.Clear();
-
         CollectBooks();
 
+        if (!skipCache && NodeDefCacheManager.TryLoadCache(AllBooks, out var cachedDefs, EditorPrefs.GetBool("RebuildOnAssemblyChange", false),
+            (current, total, percentage) =>
+            {
+                LoadingText.text = $"Loading cache: {current:N0} / {total:N0} nodes ({percentage:P0})";
+            }))
+        {
+            AllNodeDefs.AddRange(cachedDefs);
+            LoadingText.text = $"Loaded {AllNodeDefs.Count:N0} nodes from cache!";
+            Debug.Log($"[NoodleEditor] Loaded {AllNodeDefs.Count:N0} nodes from cache!");
+            _collecting = false;
+            return;
+        }
+
+        // no cache, we gotta do it the slow way
         Dictionary<CookBook, float> nodeProgression = new();
         foreach (var b in AllBooks)
             nodeProgression[b] = new();
@@ -255,43 +273,20 @@ public class UltNoodleEditor : EditorWindow
                 nodeProgression[b] = 1;
                 if (nodeProgression.Values.All(p => p == 1))
                 {
-                    LoadingText.text = $"All {AllNodeDefs.Count} Nodes Loaded!";
+                    Debug.Log($"[NoodleEditor] All {AllNodeDefs.Count:N0} nodes loaded! Saving to cache...");
+                    NodeDefCacheManager.SaveCache(AllNodeDefs,
+                        (current, total, percentage) =>
+                        {
+                            LoadingText.text = $"Saving cache: {current:N0} / {total:N0} nodes ({percentage:P0})";
+                            Debug.Log($"[NoodleEditor] Saving cache: {current:N0} / {total:N0} nodes ({percentage:P0})");
+                        });
+
+                    LoadingText.text = $"{AllNodeDefs.Count:N0} Nodes Loaded and Cached!";
+                    Debug.Log($"[NoodleEditor] All {AllNodeDefs.Count:N0} Nodes Loaded and Cached!");
                     _collecting = false;
                 }
             }));
         }
-        /*
-        int cur = 0;
-        CookBook book = AllBooks[cur];
-        IEnumerator mover = null;
-        int final = AllBooks.Count();
-
-        EditorApplication.CallbackFunction loop = null;
-        loop = () =>
-        {
-            //EditorUtility.DisplayProgressBar("Loading Noodle Editor...", book.name, (float)cur / final);
-
-            if (mover == null)
-                mover = book.CollectDefs(AllNodeDefs).GetEnumerator();
-
-            bool joever = !mover.MoveNext();
-            if (joever)
-            {
-                mover = null;
-                cur++;
-                if (cur == final)
-                {
-                    ResetSearchFilter();
-                    EditorUtility.ClearProgressBar(); 
-                    _collecting = false;
-                    LoadingText.text = "";
-                    return;
-                }
-                book = AllBooks[cur];
-            }
-            EditorApplication.delayCall += loop;
-        };
-        loop.Invoke();*/
 
     }
     private void CollectBooks()
@@ -469,7 +464,7 @@ public class UltNoodleEditor : EditorWindow
 
     [MenuItem("GameObject/Instant Noodles/UltEventHolder Bowl", true)] static bool vin1(MenuCommand command) => command.context ? !PrefabUtility.IsPartOfAnyPrefab(command.context) : true;
     [MenuItem("GameObject/Instant Noodles/UltEventHolder Bowl")]
-    static void UltEventHolderInstantNoodle(MenuCommand menuCommand) 
+    static void UltEventHolderInstantNoodle(MenuCommand menuCommand)
         => InstantInstantNoodle(menuCommand.context as GameObject, typeof(UltEventHolder), "_Event");
     [MenuItem("GameObject/Instant Noodles/DelayedUltEventHolder Bowl")]
     static void DelayedUltEventHolderInstantNoodle(MenuCommand menuCommand)
@@ -495,7 +490,6 @@ public class UltNoodleEditor : EditorWindow
         var targ = command.context as LifeCycleEvents;
         if (Editor == null) OpenWindow();
         Editor.NewBowl(targ, new SerializedType(typeof(LifeCycleEvents)), "_AwakeEvent");
-        
     }
     [MenuItem("CONTEXT/LifeCycleEvents/Noodle Bowl/Start()", true)] static bool v4(MenuCommand command) => !PrefabUtility.IsPartOfAnyPrefab(command.context);
     [MenuItem("CONTEXT/LifeCycleEvents/Noodle Bowl/Start()")]
@@ -519,9 +513,9 @@ public class UltNoodleEditor : EditorWindow
     {
         var targ = command.context as LifeCycleEvents;
         if (Editor == null) OpenWindow();
-        Editor.NewBowl(targ, new SerializedType(typeof(LifeCycleEvents)), "_DisableEvent");    
+        Editor.NewBowl(targ, new SerializedType(typeof(LifeCycleEvents)), "_DisableEvent");
     }
-    
+
     [MenuItem("CONTEXT/LifeCycleEvents/Noodle Bowl/Destroy()", true)] static bool v7(MenuCommand command) => !PrefabUtility.IsPartOfAnyPrefab(command.context);
     [MenuItem("CONTEXT/LifeCycleEvents/Noodle Bowl/Destroy()")]
     static void LifeCycleEvents_DestroyEvent(MenuCommand command)
@@ -529,7 +523,6 @@ public class UltNoodleEditor : EditorWindow
         var targ = command.context as LifeCycleEvents;
         if (Editor == null) OpenWindow();
         Editor.NewBowl(targ, new SerializedType(typeof(LifeCycleEvents)), "_DestroyEvent");
-        
     }
     [MenuItem("CONTEXT/UpdateEvents/Noodle Bowl/Update()", true)] static bool v8(MenuCommand command) => !PrefabUtility.IsPartOfAnyPrefab(command.context);
     [MenuItem("CONTEXT/UpdateEvents/Noodle Bowl/Update()")]
@@ -544,8 +537,8 @@ public class UltNoodleEditor : EditorWindow
     static void UpdateEvents_LateUpdateEvent(MenuCommand command)
     {
         var targ = command.context as UpdateEvents;
-            if (Editor == null) OpenWindow();
-            Editor.NewBowl(targ, new SerializedType(typeof(UpdateEvents)), "_LateUpdateEvent");
+        if (Editor == null) OpenWindow();
+        Editor.NewBowl(targ, new SerializedType(typeof(UpdateEvents)), "_LateUpdateEvent");
     }
     [MenuItem("CONTEXT/UpdateEvents/Noodle Bowl/Fixed Update()", true)] static bool v10(MenuCommand command) => !PrefabUtility.IsPartOfAnyPrefab(command.context);
     [MenuItem("CONTEXT/UpdateEvents/Noodle Bowl/Fixed Update()")]

--- a/Editor/UltNoodleEditor.cs
+++ b/Editor/UltNoodleEditor.cs
@@ -111,6 +111,13 @@ public class UltNoodleEditor : EditorWindow
         var helpMenu = root.Q<ToolbarMenu>("HelpMenu");
 
         nodesMenu.menu.AppendAction("Force Regenerate Nodes", (a) => CollectNodes(true), (a) => _collecting ? DropdownMenuAction.Status.Disabled : DropdownMenuAction.Status.Normal);
+
+        nodesMenu.menu.AppendAction("Use Node Cache", (a) =>
+        {
+            bool enabled = !EditorPrefs.GetBool("UseNodeCache", true);
+            EditorPrefs.SetBool("UseNodeCache", enabled);
+        }, (a) => EditorPrefs.GetBool("UseNodeCache", true) ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal);
+
         nodesMenu.menu.AppendAction("Rebuild Nodes on Assembly Change", (a) =>
         {
             bool enabled = !EditorPrefs.GetBool("RebuildOnAssemblyChange", false); // default to false, most nodes won't change on assembly since custom scripts don't work
@@ -156,7 +163,7 @@ public class UltNoodleEditor : EditorWindow
 
         if ((AllNodeDefs.Count == 0 || AllBooks == null) && !Application.isPlaying)
         {
-            CollectNodes();
+            CollectNodes(!EditorPrefs.GetBool("UseNodeCache", true));
         }
         _created = true;
     }

--- a/Editor/UltNoodleEditor.cs
+++ b/Editor/UltNoodleEditor.cs
@@ -317,12 +317,8 @@ public class UltNoodleEditor : EditorWindow
             
             var sw = System.Diagnostics.Stopwatch.StartNew();
             
-            var staticMethodDefs = new List<CookBook.NodeDef>();
-            var objectMethodDefs = new List<CookBook.NodeDef>();
             var objectFieldDefs = new List<CookBook.NodeDef>();
             
-            StaticMethodCookBook staticMethodCB = null;
-            ObjectMethodCookBook objectMethodCB = null;
             ObjectFieldCookBook objectFieldCB = null;
             
             foreach (var def in AllNodeDefs)
@@ -330,12 +326,10 @@ public class UltNoodleEditor : EditorWindow
                 switch (def.CookBook)
                 {
                     case StaticMethodCookBook smCb:
-                        if (staticMethodCB == null) staticMethodCB = smCb;
-                        staticMethodDefs.Add(def);
+                        smCb.MyDefs.Add(def);
                         break;
                     case ObjectMethodCookBook omCb:
-                        if (objectMethodCB == null) objectMethodCB = omCb;
-                        objectMethodDefs.Add(def);
+                        omCb.MyDefs.Add(def);
                         break;
                     case ObjectFieldCookBook ofCb:
                         if (objectFieldCB == null) objectFieldCB = ofCb;
@@ -345,83 +339,33 @@ public class UltNoodleEditor : EditorWindow
             }
             
             System.Threading.Tasks.Parallel.Invoke(
-                // StaticMethodCookBook
-                () => {
-                    if (staticMethodCB != null && staticMethodDefs.Count > 0)
-                    {
-                        staticMethodCB.MyDefs.Clear();
-                        staticMethodCB.MyDefs.EnsureCapacity(staticMethodDefs.Count);
-                        
-                        foreach (var def in staticMethodDefs)
-                        {
-                            try
-                            {
-                                if (string.IsNullOrEmpty(def.BookTag)) continue;
-                                SerializedMethod meth = JsonUtility.FromJson<SerializedMethod>(def.BookTag);
-                                if (meth?.Method is MethodInfo mi)
-                                    staticMethodCB.MyDefs[mi] = def;
-                            }
-                            catch { }
-                        }
-                    }
-                },
-                // ObjectMethodCookBook
-                () => {
-                    if (objectMethodCB != null && objectMethodDefs.Count > 0)
-                    {
-                        objectMethodCB.MyDefs.Clear();
-                        objectMethodCB.MyDefs.EnsureCapacity(objectMethodDefs.Count);
-                        
-                        foreach (var def in objectMethodDefs)
-                        {
-                            try
-                            {
-                                if (string.IsNullOrEmpty(def.BookTag)) continue;
-                                SerializedMethod meth = JsonUtility.FromJson<SerializedMethod>(def.BookTag);
-                                if (meth?.Method is MethodInfo mi)
-                                    objectMethodCB.MyDefs[mi] = def;
-                            }
-                            catch { }
-                        }
-                    }
-                },
                 // ObjectFieldCookBook
                 () => {
-                    if (objectFieldCB != null && objectFieldDefs.Count > 0)
+                    if (objectFieldCB == null || objectFieldDefs.Count <= 0)
+                        return;
+
+                    objectFieldCB.MyDefs.Clear();
+                        
+                    var byTag = new Dictionary<string, List<CookBook.NodeDef>>();
+                    foreach (var def in objectFieldDefs)
                     {
-                        objectFieldCB.MyDefs.Clear();
+                        if (string.IsNullOrEmpty(def.BookTag)) continue;
                         
-                        var byTag = new Dictionary<string, List<CookBook.NodeDef>>();
-                        foreach (var def in objectFieldDefs)
+                        if (!byTag.TryGetValue(def.BookTag, out var list))
                         {
-                            if (string.IsNullOrEmpty(def.BookTag)) continue;
-                            
-                            if (!byTag.TryGetValue(def.BookTag, out var list))
-                            {
-                                list = new List<CookBook.NodeDef>(2);
-                                byTag[def.BookTag] = list;
-                            }
-                            list.Add(def);
+                            list = new List<CookBook.NodeDef>(2);
+                            byTag[def.BookTag] = list;
                         }
+                        list.Add(def);
+                    }
+                    
+                    foreach (var kvp in byTag)
+                    {
+                        var getDef = kvp.Value.FirstOrDefault(d => d.Name.IndexOf(".getf_", StringComparison.Ordinal) >= 0);
+                        var setDef = kvp.Value.FirstOrDefault(d => d.Name.IndexOf(".setf_", StringComparison.Ordinal) >= 0);
                         
-                        foreach (var kvp in byTag)
-                        {
-                            try
-                            {
-                                SerializedField field = JsonUtility.FromJson<SerializedField>(kvp.Key);
-                                if (field?.Field == null) continue;
-                                
-                                FieldInfo fi = field.Field;
-                                var defs = kvp.Value;
-                                
-                                var getDef = defs.FirstOrDefault(d => d.Name.IndexOf(".getf_", StringComparison.Ordinal) >= 0);
-                                var setDef = defs.FirstOrDefault(d => d.Name.IndexOf(".setf_", StringComparison.Ordinal) >= 0);
-                                
-                                if (getDef != null && setDef != null)
-                                    objectFieldCB.MyDefs[fi] = (getDef, setDef);
-                            }
-                            catch { }
-                        }
+                        if (getDef != null && setDef != null)
+                            objectFieldCB.MyDefs.Add((getDef, setDef));
                     }
                 }
             );

--- a/Editor/UltNoodleEditor.cs
+++ b/Editor/UltNoodleEditor.cs
@@ -237,16 +237,9 @@ public class UltNoodleEditor : EditorWindow
         AllNodeDefs.Clear();
         CollectBooks();
 
-        if (!skipCache && NodeDefCacheManager.TryLoadCache(AllBooks, out var cachedDefs, EditorPrefs.GetBool("RebuildOnAssemblyChange", false),
-            (current, total, percentage) =>
-            {
-                LoadingText.text = $"Loading cache: {current:N0} / {total:N0} nodes ({percentage:P0})";
-            }))
+        if (!skipCache)
         {
-            AllNodeDefs.AddRange(cachedDefs);
-            LoadingText.text = $"Loaded {AllNodeDefs.Count:N0} nodes from cache!";
-            Debug.Log($"[NoodleEditor] Loaded {AllNodeDefs.Count:N0} nodes from cache!");
-            _collecting = false;
+            LoadNodeCache();
             return;
         }
 
@@ -307,6 +300,137 @@ public class UltNoodleEditor : EditorWindow
         if (!cookBooks.Contains(ObjectFCookBook)) cookBooks = cookBooks.Append(ObjectFCookBook);
         if (!cookBooks.Contains(StaticCookBook)) cookBooks = cookBooks.Append(StaticCookBook);
         AllBooks = cookBooks.ToArray();
+    }
+
+    private void LoadNodeCache()
+    {
+        var loadingAction = new Action<int, int, float>((current, total, percentage) =>
+            {
+                LoadingText.text = $"Loading cache: {current:N0} / {total:N0} nodes ({percentage:P0})";
+            });
+        
+        bool loaded = NodeDefCacheManager.TryLoadCache(AllBooks, out var cachedDefs, EditorPrefs.GetBool("RebuildOnAssemblyChange", false), loadingAction);
+        if (loaded)
+        {
+            AllNodeDefs.AddRange(cachedDefs);
+            LoadingText.text = $"Rebuilding cookbook indices...";
+            
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            
+            var staticMethodDefs = new List<CookBook.NodeDef>();
+            var objectMethodDefs = new List<CookBook.NodeDef>();
+            var objectFieldDefs = new List<CookBook.NodeDef>();
+            
+            StaticMethodCookBook staticMethodCB = null;
+            ObjectMethodCookBook objectMethodCB = null;
+            ObjectFieldCookBook objectFieldCB = null;
+            
+            foreach (var def in AllNodeDefs)
+            {
+                switch (def.CookBook)
+                {
+                    case StaticMethodCookBook smCb:
+                        if (staticMethodCB == null) staticMethodCB = smCb;
+                        staticMethodDefs.Add(def);
+                        break;
+                    case ObjectMethodCookBook omCb:
+                        if (objectMethodCB == null) objectMethodCB = omCb;
+                        objectMethodDefs.Add(def);
+                        break;
+                    case ObjectFieldCookBook ofCb:
+                        if (objectFieldCB == null) objectFieldCB = ofCb;
+                        objectFieldDefs.Add(def);
+                        break;
+                }
+            }
+            
+            System.Threading.Tasks.Parallel.Invoke(
+                // StaticMethodCookBook
+                () => {
+                    if (staticMethodCB != null && staticMethodDefs.Count > 0)
+                    {
+                        staticMethodCB.MyDefs.Clear();
+                        staticMethodCB.MyDefs.EnsureCapacity(staticMethodDefs.Count);
+                        
+                        foreach (var def in staticMethodDefs)
+                        {
+                            try
+                            {
+                                if (string.IsNullOrEmpty(def.BookTag)) continue;
+                                SerializedMethod meth = JsonUtility.FromJson<SerializedMethod>(def.BookTag);
+                                if (meth?.Method is MethodInfo mi)
+                                    staticMethodCB.MyDefs[mi] = def;
+                            }
+                            catch { }
+                        }
+                    }
+                },
+                // ObjectMethodCookBook
+                () => {
+                    if (objectMethodCB != null && objectMethodDefs.Count > 0)
+                    {
+                        objectMethodCB.MyDefs.Clear();
+                        objectMethodCB.MyDefs.EnsureCapacity(objectMethodDefs.Count);
+                        
+                        foreach (var def in objectMethodDefs)
+                        {
+                            try
+                            {
+                                if (string.IsNullOrEmpty(def.BookTag)) continue;
+                                SerializedMethod meth = JsonUtility.FromJson<SerializedMethod>(def.BookTag);
+                                if (meth?.Method is MethodInfo mi)
+                                    objectMethodCB.MyDefs[mi] = def;
+                            }
+                            catch { }
+                        }
+                    }
+                },
+                // ObjectFieldCookBook
+                () => {
+                    if (objectFieldCB != null && objectFieldDefs.Count > 0)
+                    {
+                        objectFieldCB.MyDefs.Clear();
+                        
+                        var byTag = new Dictionary<string, List<CookBook.NodeDef>>();
+                        foreach (var def in objectFieldDefs)
+                        {
+                            if (string.IsNullOrEmpty(def.BookTag)) continue;
+                            
+                            if (!byTag.TryGetValue(def.BookTag, out var list))
+                            {
+                                list = new List<CookBook.NodeDef>(2);
+                                byTag[def.BookTag] = list;
+                            }
+                            list.Add(def);
+                        }
+                        
+                        foreach (var kvp in byTag)
+                        {
+                            try
+                            {
+                                SerializedField field = JsonUtility.FromJson<SerializedField>(kvp.Key);
+                                if (field?.Field == null) continue;
+                                
+                                FieldInfo fi = field.Field;
+                                var defs = kvp.Value;
+                                
+                                var getDef = defs.FirstOrDefault(d => d.Name.IndexOf(".getf_", StringComparison.Ordinal) >= 0);
+                                var setDef = defs.FirstOrDefault(d => d.Name.IndexOf(".setf_", StringComparison.Ordinal) >= 0);
+                                
+                                if (getDef != null && setDef != null)
+                                    objectFieldCB.MyDefs[fi] = (getDef, setDef);
+                            }
+                            catch { }
+                        }
+                    }
+                }
+            );
+            
+            sw.Stop();
+            LoadingText.text = $"Loaded {AllNodeDefs.Count:N0} nodes from cache!";
+            Debug.Log($"[NoodleEditor] Loaded {AllNodeDefs.Count:N0} nodes from cache! Cookbook indices rebuilt in {sw.ElapsedMilliseconds}ms");
+            _collecting = false;
+        }
     }
 
     private bool _created = false;

--- a/SerializedField.cs
+++ b/SerializedField.cs
@@ -22,6 +22,11 @@ namespace NoodledEvents
         private FieldInfo f;
         [SerializeField] string _assemblyTypeName;
         [SerializeField] string _fieldName;
+
+        public static string GetBookTag(FieldInfo field)
+        {
+            return $"{{\"_assemblyTypeName\":\"{field.DeclaringType.AssemblyQualifiedName}\",\"_fieldName\":\"{field.Name}\"}}";
+        }
     }
 }
 #endif

--- a/SerializedMethod.cs
+++ b/SerializedMethod.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using UltEvents;
 using UnityEngine;
 
@@ -25,6 +26,28 @@ namespace NoodledEvents
         private MethodBase m;
         [SerializeField] string _assemblyMethodName;
         [SerializeField] public SerializedType[] Parameters;
+
+        public static string GetBookTag(MethodInfo method)
+        {
+            StringBuilder sb = new();
+            // method name and type
+            sb.Append($"{{\"_assemblyMethodName\":\"{UltEventUtils.GetFullyQualifiedName(method)}\",\"Parameters\":");
+
+            // build parameters
+            sb.Append("[");
+            var parameters = method.GetParameters();
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                sb.Append($"{{\"_assemblyTypeName\":\"{parameters[i].ParameterType.AssemblyQualifiedName}\"}}");
+                if (i < parameters.Length - 1) sb.Append(",");
+            }
+            sb.Append("]");
+
+            // done
+            sb.Append("}");
+
+            return sb.ToString();
+        }
     }
 }
 #endif


### PR DESCRIPTION
To be clear, nearly everything in the initial commit was written by AI, however, I have manually reviewed the code, adjusted it, and have been testing it for a while and haven't had any problems (others have also been using it for some time and all issues brought up have been fixed).

Implements a node cache system to lower the editor start time after the NodeDefs are cleared (entering/exiting play mode, restarting the editor, etc).
On my system, it reduces the (very laggy) ~1 minute long node loading time to ~10 seconds.
The caching adds around 15 seconds to the initial load time and uses ~23MB in my project.

The saving/loading process does lock up the editor, however, given it's only 10 seconds, it's plenty usable in my opinion.